### PR TITLE
Reduce docker image size

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+all: push
+
+# 0.0 shouldn't clobber any release builds
+TAG = 0.0
+PREFIX = kobolog/gorb
+
+binary: main.go
+	CGO_ENABLED=0 GOOS=linux godep go build -a -ldflags '-w' -o docker/gorb
+
+container: binary
+	docker build -t $(PREFIX):$(TAG) docker
+
+push: container
+	docker push $(PREFIX):$(TAG)
+
+clean:
+	rm -f /docker/gorb

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,8 @@
-FROM        golang
+FROM        scratch
 MAINTAINER  Andrey Sibiryov <me@kobology.ru>
-RUN         go get github.com/kobolog/gorb
+
 EXPOSE      4672
-ENTRYPOINT  ["gorb"]
+
+COPY gorb   /gorb
+
+ENTRYPOINT  ["/gorb"]


### PR DESCRIPTION
using scratch as base image and compiling gorb binary as a static binary using godep

```
kobolog/gorb        0.0                 cab748ec88a0        23 minutes ago      6.218 MB
kobolog/gorb        latest              95feb864e584        8 days ago          722.8 MB
```