### PR TITLE
Register the REST service provided by Gorb isself to Consul.

### DIFF
--- a/core/context.go
+++ b/core/context.go
@@ -93,6 +93,10 @@ func NewContext(options ContextOptions) (*Context, error) {
 	if len(options.Endpoints) > 0 {
 		// TODO(@kobolog): Bind virtual services on multiple endpoints.
 		ctx.endpoint = options.Endpoints[0]
+		if options.ListenPort != 0 {
+			log.Info("Registered the REST service to Consul.")
+			ctx.disco.Expose("gorb", ctx.endpoint.String(), options.ListenPort)
+		}
 	}
 
 	if err := ctx.ipvs.Init(); err != nil {

--- a/core/options.go
+++ b/core/options.go
@@ -40,9 +40,10 @@ var (
 
 // ContextOptions configure Context behavior.
 type ContextOptions struct {
-	Disco     string
-	Endpoints []net.IP
-	Flush     bool
+	Disco      string
+	Endpoints  []net.IP
+	Flush      bool
+	ListenPort uint16
 }
 
 // ServiceOptions describe a virtual service.

--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ package main
 
 import (
 	"flag"
+	"net"
 	"net/http"
 	"os"
 
@@ -59,10 +60,18 @@ func main() {
 		log.Fatalf("error while obtaining interface addresses: %s", err)
 	}
 
+	tcpAddr, err := net.ResolveTCPAddr("tcp", *listen)
+	port := uint16(0)
+	if err != nil {
+		log.Fatalf("error while obtaining listening port from (%s): %s", *listen, err)
+	} else {
+		port = uint16(tcpAddr.Port)
+	}
 	ctx, err := core.NewContext(core.ContextOptions{
-		Disco:     *consul,
-		Endpoints: hostIPs,
-		Flush:     *flush})
+		Disco:      *consul,
+		Endpoints:  hostIPs,
+		Flush:      *flush,
+		ListenPort: port})
 
 	if err != nil {
 		log.Fatalf("error while initializing server context: %s", err)


### PR DESCRIPTION
It makes finding the location of load balancer easier.
Just by `dig gorb.service.counsl @localhost`
Also it will make fail over easier with using Consul's event functions.