### PR TITLE
Add prometheus monitoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ _testmain.go
 *.exe
 *.test
 *.prof
+
+docker/gorb
+Godeps/_workspace

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ install:
   - go get github.com/sirupsen/logrus
   - go get github.com/tehnerd/gnl2go
   - go get github.com/fsouza/go-dockerclient
+  - go get github.com/prometheus/client_golang/prometheus
 
 script:
   - ./.travis/script.sh . core disco pulse util gorb-docker-link

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ install:
   - go get github.com/stretchr/testify/assert
   - go get github.com/stretchr/testify/require
   - go get github.com/gorilla/mux
-  - go get github.com/sirupsen/logrus
+  - go get github.com/Sirupsen/logrus
   - go get github.com/tehnerd/gnl2go
   - go get github.com/fsouza/go-dockerclient
   - go get github.com/prometheus/client_golang/prometheus

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,6 +1,7 @@
 {
 	"ImportPath": "github.com/kobolog/gorb",
 	"GoVersion": "go1.5",
+	"GodepVersion": "v58",
 	"Packages": [
 		"github.com/kobolog/gorb",
 		"github.com/kobolog/gorb/core",
@@ -10,12 +11,88 @@
 	],
 	"Deps": [
 		{
+			"ImportPath": "github.com/beorn7/perks/quantile",
+			"Rev": "3ac7bf7a47d159a033b107610db8a1b6575507a4"
+		},
+		{
 			"ImportPath": "github.com/davecgh/go-spew/spew",
 			"Rev": "5215b55f46b2b919f50a1df0eaa5886afe4e3b3d"
 		},
 		{
 			"ImportPath": "github.com/fsouza/go-dockerclient",
 			"Rev": "0f5764b4d2f5b8928a05db1226a508817a9a01dd"
+		},
+		{
+			"ImportPath": "github.com/fsouza/go-dockerclient/external/github.com/Sirupsen/logrus",
+			"Rev": "0f5764b4d2f5b8928a05db1226a508817a9a01dd"
+		},
+		{
+			"ImportPath": "github.com/fsouza/go-dockerclient/external/github.com/docker/docker/opts",
+			"Rev": "0f5764b4d2f5b8928a05db1226a508817a9a01dd"
+		},
+		{
+			"ImportPath": "github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/archive",
+			"Rev": "0f5764b4d2f5b8928a05db1226a508817a9a01dd"
+		},
+		{
+			"ImportPath": "github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/fileutils",
+			"Rev": "0f5764b4d2f5b8928a05db1226a508817a9a01dd"
+		},
+		{
+			"ImportPath": "github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/homedir",
+			"Rev": "0f5764b4d2f5b8928a05db1226a508817a9a01dd"
+		},
+		{
+			"ImportPath": "github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/idtools",
+			"Rev": "0f5764b4d2f5b8928a05db1226a508817a9a01dd"
+		},
+		{
+			"ImportPath": "github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/ioutils",
+			"Rev": "0f5764b4d2f5b8928a05db1226a508817a9a01dd"
+		},
+		{
+			"ImportPath": "github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/longpath",
+			"Rev": "0f5764b4d2f5b8928a05db1226a508817a9a01dd"
+		},
+		{
+			"ImportPath": "github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/parsers",
+			"Rev": "0f5764b4d2f5b8928a05db1226a508817a9a01dd"
+		},
+		{
+			"ImportPath": "github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/pools",
+			"Rev": "0f5764b4d2f5b8928a05db1226a508817a9a01dd"
+		},
+		{
+			"ImportPath": "github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/promise",
+			"Rev": "0f5764b4d2f5b8928a05db1226a508817a9a01dd"
+		},
+		{
+			"ImportPath": "github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/stdcopy",
+			"Rev": "0f5764b4d2f5b8928a05db1226a508817a9a01dd"
+		},
+		{
+			"ImportPath": "github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/system",
+			"Rev": "0f5764b4d2f5b8928a05db1226a508817a9a01dd"
+		},
+		{
+			"ImportPath": "github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/ulimit",
+			"Rev": "0f5764b4d2f5b8928a05db1226a508817a9a01dd"
+		},
+		{
+			"ImportPath": "github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/units",
+			"Rev": "0f5764b4d2f5b8928a05db1226a508817a9a01dd"
+		},
+		{
+			"ImportPath": "github.com/fsouza/go-dockerclient/external/github.com/hashicorp/go-cleanhttp",
+			"Rev": "0f5764b4d2f5b8928a05db1226a508817a9a01dd"
+		},
+		{
+			"ImportPath": "github.com/fsouza/go-dockerclient/external/github.com/opencontainers/runc/libcontainer/user",
+			"Rev": "0f5764b4d2f5b8928a05db1226a508817a9a01dd"
+		},
+		{
+			"ImportPath": "github.com/golang/protobuf/proto",
+			"Rev": "62e4364d64b32762febb61f2c88c0a29bc49a225"
 		},
 		{
 			"ImportPath": "github.com/gorilla/context",
@@ -26,8 +103,38 @@
 			"Rev": "9c068cf16d982f8bd444b8c352acbeec34c4fe5b"
 		},
 		{
+			"ImportPath": "github.com/matttproud/golang_protobuf_extensions/pbutil",
+			"Rev": "d0c3fe89de86839aecf2e0579c40ba3bb336a453"
+		},
+		{
 			"ImportPath": "github.com/pmezard/go-difflib/difflib",
 			"Rev": "d8ed2627bdf02c080bf22230dbb337003b7aba2d"
+		},
+		{
+			"ImportPath": "github.com/prometheus/client_golang/prometheus",
+			"Comment": "0.7.0-76-gb90ee08",
+			"Rev": "b90ee0840e8e7dfb84c08d13b9c4f3a794586a21"
+		},
+		{
+			"ImportPath": "github.com/prometheus/client_model/go",
+			"Comment": "model-0.0.2-12-gfa8ad6f",
+			"Rev": "fa8ad6fec33561be4280a8f0514318c79d7f6cb6"
+		},
+		{
+			"ImportPath": "github.com/prometheus/common/expfmt",
+			"Rev": "dd586c1c5abb0be59e60f942c22af711a2008cb4"
+		},
+		{
+			"ImportPath": "github.com/prometheus/common/internal/bitbucket.org/ww/goautoneg",
+			"Rev": "dd586c1c5abb0be59e60f942c22af711a2008cb4"
+		},
+		{
+			"ImportPath": "github.com/prometheus/common/model",
+			"Rev": "dd586c1c5abb0be59e60f942c22af711a2008cb4"
+		},
+		{
+			"ImportPath": "github.com/prometheus/procfs",
+			"Rev": "abf152e5f3e97f2fafac028d2cc06c1feb87ffa5"
 		},
 		{
 			"ImportPath": "github.com/sirupsen/logrus",
@@ -47,6 +154,10 @@
 		{
 			"ImportPath": "github.com/tehnerd/gnl2go",
 			"Rev": "804f9a72f673ff3e29b7a21436bf9e57426a7070"
+		},
+		{
+			"ImportPath": "golang.org/x/sys/unix",
+			"Rev": "33267e036fd93fcd26ea95b7bdaf2d8306cb743c"
 		}
 	]
 }

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -11,6 +11,11 @@
 	],
 	"Deps": [
 		{
+			"ImportPath": "github.com/Sirupsen/logrus",
+			"Comment": "v0.10.0",
+			"Rev": "4b6ea7319e214d98c938f12692336f7ca9348d6b"
+		},
+		{
 			"ImportPath": "github.com/beorn7/perks/quantile",
 			"Rev": "3ac7bf7a47d159a033b107610db8a1b6575507a4"
 		},
@@ -135,11 +140,6 @@
 		{
 			"ImportPath": "github.com/prometheus/procfs",
 			"Rev": "abf152e5f3e97f2fafac028d2cc06c1feb87ffa5"
-		},
-		{
-			"ImportPath": "github.com/sirupsen/logrus",
-			"Comment": "v0.8.7-47-ga22723f",
-			"Rev": "a22723f16efea2e89b7bd67d10ed077c47c14eb4"
 		},
 		{
 			"ImportPath": "github.com/stretchr/testify/assert",

--- a/README.md
+++ b/README.md
@@ -64,11 +64,11 @@ For more information and various configuration options description, consult [`ma
 Gorb exposes Prometheus consumable metrics on http://<listening-IP>:4672/metrics
 
 ### Available timeseries
-* gorb_lbs_health
-* gorb_lbs_backends_health
-* gorb_lbs_backends_number
-* gorb_lbs_backends_weight
-* gorb_lbs_backends_status
+* gorb_lbs_health - service health from 0 to 1
+* gorb_lbs_backends_health - backends health from 0 to 1
+* gorb_lbs_backends_number - number of backends per service
+* gorb_lbs_backends_weight - backends weight from 0 to 100
+* gorb_lbs_backends_status - 0 alive, 1 dead
 
 ### Example
 ```sh

--- a/README.md
+++ b/README.md
@@ -55,8 +55,46 @@ address automatically based on the configured default device:
 - `DELETE /service/<service>/<backend>` removes the specified backend from the virtual service.
 - `GET /service/<service>` returns virtual service configuration.
 - `GET /service/<service>/<backend>` returns backend configuration and its health check metrics.
+- `PATCH /service/<service>` updates virtual service configuration.
+- `PATCH /service/<service>/<backend>` updates backend configuration.
 
 For more information and various configuration options description, consult [`man 8 ipvsadm`](http://linux.die.net/man/8/ipvsadm).
+
+## Monitoring
+Gorb exposes Prometheus consumable metrics on http://<listening-IP>:4672/metrics
+
+### Available timeseries
+* gorb_lbs_health
+* gorb_lbs_backends_health
+* gorb_lbs_backends_number
+* gorb_lbs_backends_weight
+* gorb_lbs_backends_status
+
+### Example
+```sh
+curl http://gorb:4672/metrics |grep gorb_lbs
+...
+gorb_lbs_health{host="",lb_name="nginx-443",method="wlc",persistent="true",port="443",protocol="tcp"} 0.5
+gorb_lbs_health{host="",lb_name="nginx-80",method="wlc",persistent="true",port="443",protocol="tcp"} 1
+...
+gorb_lbs_backends_number{host="",lb_name="nginx-443",method="wlc",port="443"} 2
+gorb_lbs_backends_number{host="",lb_name="nginx-80",method="wlc",port="443"} 2
+...
+gorb_lbs_backends_health{backend_name="10.0.0.4-443",host="10.0.0.4",lb_name="nginx-443",method="nat",port="443"} 1
+gorb_lbs_backends_health{backend_name="10.0.128.2-443",host="10.0.128.2",lb_name="nginx-443",method="nat",port="443"} 0
+gorb_lbs_backends_health{backend_name="10.0.160.2-80",host="10.0.160.2",lb_name="nginx-80",method="nat",port="80"} 1
+gorb_lbs_backends_health{backend_name="10.0.32.2-80",host="10.0.32.2",lb_name="nginx-80",method="nat",port="80"} 1
+...
+gorb_lbs_backends_status{backend_name="10.0.0.4-443",host="10.0.0.4",lb_name="nginx-443",method="nat",port="443"} 0
+gorb_lbs_backends_status{backend_name="10.0.128.2-443",host="10.0.128.2",lb_name="nginx-443",method="nat",port="443"} 1
+gorb_lbs_backends_status{backend_name="10.0.160.2-80",host="10.0.160.2",lb_name="nginx-80",method="nat",port="80"} 0
+gorb_lbs_backends_status{backend_name="10.0.32.2-80",host="10.0.32.2",lb_name="nginx-80",method="nat",port="80"} 0
+...
+gorb_lbs_backends_weight{backend_name="10.0.0.4-443",host="10.0.0.4",lb_name="nginx.crisidev.org-443",method="nat",port="443"} 100
+gorb_lbs_backends_weight{backend_name="10.0.128.2-443",host="10.0.128.2",lb_name="nginx.crisidev.org-443",method="nat",port="443"} 0
+gorb_lbs_backends_weight{backend_name="10.0.160.2-80",host="10.0.160.2",lb_name="nginx.crisidev.org-80",method="nat",port="80"} 50
+gorb_lbs_backends_weight{backend_name="10.0.32.2-80",host="10.0.32.2",lb_name="nginx.crisidev.org-80",method="nat",port="80"} 50
+```
 
 ## TODO
 
@@ -67,3 +105,4 @@ For more information and various configuration options description, consult [`ma
 - [ ] Add BGP host-route announces, so that multiple GORBs could expose a service on the same IP across the cluster.
 - [ ] Add some primitive UI to present the same action palette but in an user-friendly fashion.
 - [ ] Replace command line options with proper configuration via a JSON/YAML/TOML file.
+- [x] Add monitoring

--- a/core/context.go
+++ b/core/context.go
@@ -29,7 +29,7 @@ import (
 	"github.com/kobolog/gorb/pulse"
 	"github.com/kobolog/gorb/util"
 
-	log "github.com/sirupsen/logrus"
+	log "github.com/Sirupsen/logrus"
 	"github.com/tehnerd/gnl2go"
 )
 

--- a/core/metrics.go
+++ b/core/metrics.go
@@ -25,8 +25,8 @@ import (
 	"strconv"
 	"time"
 
+	log "github.com/Sirupsen/logrus"
 	"github.com/prometheus/client_golang/prometheus"
-	log "github.com/sirupsen/logrus"
 )
 
 const (

--- a/core/metrics.go
+++ b/core/metrics.go
@@ -1,0 +1,152 @@
+/*
+   Copyright (c) 2015 Andrey Sibiryov <me@kobology.ru>
+   Copyright (c) 2015 Other contributors as noted in the AUTHORS file.
+
+   This file is part of GORB - Go Routing and Balancing.
+
+   GORB is free software; you can redistribute it and/or modify
+   it under the terms of the GNU Lesser General Public License as published by
+   the Free Software Foundation; either version 3 of the License, or
+   (at your option) any later version.
+
+   GORB is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public License
+   along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package core
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	promNamespace = "gorb"
+	defaultSleep  = time.Second * 5
+)
+
+var (
+	lbHealth = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: promNamespace,
+		Name:      "lbs_health",
+		Help:      "load balancers health percentage",
+	}, []string{"lb_name", "host", "port", "protocol", "persistent", "method"})
+	backendNumber = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: promNamespace,
+		Name:      "lbs_backends_number",
+		Help:      "load balancers backends informations",
+	}, []string{"lb_name", "host", "port", "method"})
+	backendWeight = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: promNamespace,
+		Name:      "lbs_backends_weight",
+		Help:      "load balancers backends weight",
+	}, []string{"lb_name", "backend_name", "host", "port", "method"})
+	backendStatus = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: promNamespace,
+		Name:      "lbs_backends_status",
+		Help:      "load balancers backends status",
+	}, []string{"lb_name", "backend_name", "host", "port", "method"})
+	backendHealth = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: promNamespace,
+		Name:      "lbs_backends_health",
+		Help:      "load balancers backends health",
+	}, []string{"lb_name", "backend_name", "host", "port", "method"})
+	lbChannelMap      = make(map[string]chan int)
+	backendChannelMap = make(map[string]chan int)
+)
+
+// Prometheus time series
+func init() {
+	prometheus.MustRegister(lbHealth)
+	prometheus.MustRegister(backendNumber)
+	prometheus.MustRegister(backendWeight)
+	prometheus.MustRegister(backendStatus)
+	prometheus.MustRegister(backendHealth)
+}
+
+func StartLBMetric(ctx *Context, vsID string) {
+	lbChannelMap[vsID] = make(chan int)
+	for {
+		select {
+		case _ = <-lbChannelMap[vsID]:
+			return
+		default:
+			service, err := ctx.GetService(vsID)
+			if err != nil {
+				log.Errorf("Error retrieving service %s: %s", vsID, err)
+			} else {
+				lbHealth.WithLabelValues(vsID, service.Options.Host, fmt.Sprintf("%v", service.Options.Port), service.Options.Protocol, strconv.FormatBool(service.Options.Persistent), service.Options.Method).Set(service.Health)
+			}
+			time.Sleep(defaultSleep)
+		}
+	}
+}
+
+func StartBackendMetric(ctx *Context, vsID, rsID string) {
+	backendChannelMap[rsID] = make(chan int)
+	rs, exists := ctx.backends[rsID]
+	if !exists {
+		log.Errorf("Error retrieving backend %s", rsID)
+	} else {
+		backendNumber.WithLabelValues(vsID, rs.service.options.Host, fmt.Sprintf("%v", rs.service.options.Port), rs.service.options.Method).Inc()
+		for {
+			select {
+			case _ = <-backendChannelMap[rsID]:
+				return
+			default:
+				// Update backend health every 5 seconds
+				backend, err := ctx.GetBackend(vsID, rsID)
+				if err != nil {
+					log.Errorf("Error retrieving service %s or backend %s: %s", vsID, rsID, err)
+				} else {
+					backendStatus.WithLabelValues(vsID, rsID, backend.Options.Host, fmt.Sprintf("%v", backend.Options.Port), backend.Options.Method).Set(float64(backend.Metrics.Status))
+					backendHealth.WithLabelValues(vsID, rsID, backend.Options.Host, fmt.Sprintf("%v", backend.Options.Port), backend.Options.Method).Set(backend.Metrics.Health)
+					backendWeight.WithLabelValues(vsID, rsID, backend.Options.Host, fmt.Sprintf("%v", backend.Options.Port), backend.Options.Method).Set(float64(backend.Options.Weight))
+				}
+				time.Sleep(defaultSleep)
+			}
+		}
+	}
+}
+
+func StopLBMetric(ctx *Context, vsID string) {
+	service, err := ctx.GetService(vsID)
+	if err != nil {
+		log.Errorf("Error retrieving service %s: %s", vsID, err)
+	} else {
+		if ch, found := lbChannelMap[vsID]; found {
+			ch <- 0
+			delete(lbChannelMap, vsID)
+			lbHealth.Delete(prometheus.Labels{"lb_name": vsID, "host": service.Options.Host, "port": fmt.Sprintf("%v", service.Options.Port), "method": service.Options.Method, "protocol": service.Options.Protocol, "persistent": strconv.FormatBool(service.Options.Persistent)})
+		} else {
+			log.Errorf("%s not found inside lbChannelMap keys", vsID)
+		}
+	}
+}
+
+func StopBackendMetric(ctx *Context, vsID, rsID string) {
+	rs, exists := ctx.backends[rsID]
+	if !exists {
+		log.Errorf("Error retrieving backend %s", rsID)
+	} else {
+		if ch, found := backendChannelMap[rsID]; found {
+			ch <- 0
+			delete(backendChannelMap, rsID)
+			backendNumber.WithLabelValues(vsID, rs.service.options.Host, fmt.Sprintf("%v", rs.service.options.Port), rs.service.options.Method).Dec()
+			backendHealth.Delete(prometheus.Labels{"lb_name": vsID, "backend_name": rsID, "host": rs.options.Host, "port": fmt.Sprintf("%v", rs.options.Port), "method": rs.options.Method})
+			backendStatus.Delete(prometheus.Labels{"lb_name": vsID, "backend_name": rsID, "host": rs.options.Host, "port": fmt.Sprintf("%v", rs.options.Port), "method": rs.options.Method})
+			backendWeight.Delete(prometheus.Labels{"lb_name": vsID, "backend_name": rsID, "host": rs.options.Host, "port": fmt.Sprintf("%v", rs.options.Port), "method": rs.options.Method})
+		} else {
+			log.Errorf("%s not found inside backendChannelMap keys", rsID)
+		}
+	}
+}

--- a/core/sink.go
+++ b/core/sink.go
@@ -23,7 +23,7 @@ package core
 import (
 	"github.com/kobolog/gorb/pulse"
 
-	log "github.com/sirupsen/logrus"
+	log "github.com/Sirupsen/logrus"
 )
 
 func (ctx *Context) notificationLoop() {

--- a/gorb-docker-link/main.go
+++ b/gorb-docker-link/main.go
@@ -34,8 +34,8 @@ import (
 	"github.com/kobolog/gorb/pulse"
 	"github.com/kobolog/gorb/util"
 
+	log "github.com/Sirupsen/logrus"
 	gdc "github.com/fsouza/go-dockerclient"
-	log "github.com/sirupsen/logrus"
 )
 
 var (

--- a/main.go
+++ b/main.go
@@ -30,6 +30,7 @@ import (
 	"github.com/kobolog/gorb/util"
 
 	"github.com/gorilla/mux"
+	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -67,6 +68,7 @@ func main() {
 	} else {
 		port = uint16(tcpAddr.Port)
 	}
+
 	ctx, err := core.NewContext(core.ContextOptions{
 		Disco:      *consul,
 		Endpoints:  hostIPs,
@@ -82,6 +84,7 @@ func main() {
 
 	r := mux.NewRouter()
 
+	r.Handle("/metrics", prometheus.Handler()).Methods("GET")
 	r.Handle("/service/{vsID}", serviceCreateHandler{ctx}).Methods("PUT")
 	r.Handle("/service/{vsID}/{rsID}", backendCreateHandler{ctx}).Methods("PUT")
 	r.Handle("/service/{vsID}/{rsID}", backendUpdateHandler{ctx}).Methods("PATCH")

--- a/main.go
+++ b/main.go
@@ -29,9 +29,9 @@ import (
 	"github.com/kobolog/gorb/core"
 	"github.com/kobolog/gorb/util"
 
+	log "github.com/Sirupsen/logrus"
 	"github.com/gorilla/mux"
 	"github.com/prometheus/client_golang/prometheus"
-	log "github.com/sirupsen/logrus"
 )
 
 var (

--- a/pulse/http.go
+++ b/pulse/http.go
@@ -29,7 +29,7 @@ import (
 
 	"github.com/kobolog/gorb/util"
 
-	log "github.com/sirupsen/logrus"
+	log "github.com/Sirupsen/logrus"
 )
 
 var (

--- a/pulse/pulse.go
+++ b/pulse/pulse.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/kobolog/gorb/util"
 
-	log "github.com/sirupsen/logrus"
+	log "github.com/Sirupsen/logrus"
 )
 
 // Driver provides the actual health check for Pulse.

--- a/pulse/tcp.go
+++ b/pulse/tcp.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/kobolog/gorb/util"
 
-	log "github.com/sirupsen/logrus"
+	log "github.com/Sirupsen/logrus"
 )
 
 type tcpPulse struct {


### PR DESCRIPTION
This is how I instructed Gorb to produce metrics to be consumed by my Prometheus server.

Every time a service or a backend is created, a new time-serie is exposed. The related goroutine updates health metrics from the Pulse.
Once the backed or the service is removed, the related time-serie is deleted to allow Prometheus knows about the change.

Gorb exposes Prometheus consumable metrics on http://<listening-IP>:4672/metrics
### Available timeseries
- gorb_lbs_health
- gorb_lbs_backends_health
- gorb_lbs_backends_number
- gorb_lbs_backends_weight
- gorb_lbs_backends_status
### Example

``` sh
curl http://gorb:4672/metrics |grep gorb_lbs
...
gorb_lbs_health{host="",lb_name="nginx-443",method="wlc",persistent="true",port="443",protocol="tcp"} 0.5
gorb_lbs_health{host="",lb_name="nginx-80",method="wlc",persistent="true",port="443",protocol="tcp"} 1
...
gorb_lbs_backends_number{host="",lb_name="nginx-443",method="wlc",port="443"} 2
gorb_lbs_backends_number{host="",lb_name="nginx-80",method="wlc",port="443"} 2
...
gorb_lbs_backends_health{backend_name="10.0.0.4-443",host="10.0.0.4",lb_name="nginx-443",method="nat",port="443"} 1
gorb_lbs_backends_health{backend_name="10.0.128.2-443",host="10.0.128.2",lb_name="nginx-443",method="nat",port="443"} 0
gorb_lbs_backends_health{backend_name="10.0.160.2-80",host="10.0.160.2",lb_name="nginx-80",method="nat",port="80"} 1
gorb_lbs_backends_health{backend_name="10.0.32.2-80",host="10.0.32.2",lb_name="nginx-80",method="nat",port="80"} 1
...
gorb_lbs_backends_status{backend_name="10.0.0.4-443",host="10.0.0.4",lb_name="nginx-443",method="nat",port="443"} 0
gorb_lbs_backends_status{backend_name="10.0.128.2-443",host="10.0.128.2",lb_name="nginx-443",method="nat",port="443"} 1
gorb_lbs_backends_status{backend_name="10.0.160.2-80",host="10.0.160.2",lb_name="nginx-80",method="nat",port="80"} 0
gorb_lbs_backends_status{backend_name="10.0.32.2-80",host="10.0.32.2",lb_name="nginx-80",method="nat",port="80"} 0
...
gorb_lbs_backends_weight{backend_name="10.0.0.4-443",host="10.0.0.4",lb_name="nginx.crisidev.org-443",method="nat",port="443"} 100
gorb_lbs_backends_weight{backend_name="10.0.128.2-443",host="10.0.128.2",lb_name="nginx.crisidev.org-443",method="nat",port="443"} 0
gorb_lbs_backends_weight{backend_name="10.0.160.2-80",host="10.0.160.2",lb_name="nginx.crisidev.org-80",method="nat",port="80"} 50
gorb_lbs_backends_weight{backend_name="10.0.32.2-80",host="10.0.32.2",lb_name="nginx.crisidev.org-80",method="nat",port="80"} 50
```
### Dashboard

This allows you to create a dashboard like this:

![Prometheus Dashboard](http://i.imgur.com/Zu4g51b.png)
