### PR TITLE
Remove interface addresses(VIPs) when remove services if it were adde…

### DIFF
--- a/core/context.go
+++ b/core/context.go
@@ -171,6 +171,8 @@ func (ctx *Context) CreateService(vsID string, opts *ServiceOptions) error {
 			log.Infof(
 				"failed to add VIP %s to interface '%s' for service [%s]: %s",
 				opts.host, ifName, vsID, err)
+		} else {
+			opts.DelIfAddr = true
 		}
 		log.Infof("VIP %s has been added to interface '%s'", opts.host, ifName)
 	}
@@ -299,6 +301,18 @@ func (ctx *Context) RemoveService(vsID string) (*ServiceOptions, error) {
 	}
 
 	delete(ctx.services, vsID)
+
+	if ctx.vipInterface != nil && vs.options.DelIfAddr == true {
+		ifName := ctx.vipInterface.Attrs().Name
+		vip := &netlink.Addr{IPNet: &net.IPNet{
+			net.ParseIP(vs.options.host.String()), net.IPv4Mask(255, 255, 255, 255)}}
+		if err := netlink.AddrDel(ctx.vipInterface, vip); err != nil {
+			log.Infof(
+				"failed to delete VIP %s to interface '%s' for service [%s]: %s",
+				vs.options.host, ifName, vsID, err)
+		}
+		log.Infof("VIP %s has been deleted from interface '%s'", vs.options.host, ifName)
+	}
 
 	log.Infof("removing virtual service [%s] from %s:%d", vsID,
 		vs.options.host,

--- a/core/context.go
+++ b/core/context.go
@@ -172,7 +172,7 @@ func (ctx *Context) CreateService(vsID string, opts *ServiceOptions) error {
 				"failed to add VIP %s to interface '%s' for service [%s]: %s",
 				opts.host, ifName, vsID, err)
 		} else {
-			opts.DelIfAddr = true
+			opts.delIfAddr = true
 		}
 		log.Infof("VIP %s has been added to interface '%s'", opts.host, ifName)
 	}
@@ -302,7 +302,7 @@ func (ctx *Context) RemoveService(vsID string) (*ServiceOptions, error) {
 
 	delete(ctx.services, vsID)
 
-	if ctx.vipInterface != nil && vs.options.DelIfAddr == true {
+	if ctx.vipInterface != nil && vs.options.delIfAddr == true {
 		ifName := ctx.vipInterface.Attrs().Name
 		vip := &netlink.Addr{IPNet: &net.IPNet{
 			net.ParseIP(vs.options.host.String()), net.IPv4Mask(255, 255, 255, 255)}}

--- a/core/options.go
+++ b/core/options.go
@@ -56,11 +56,11 @@ type ServiceOptions struct {
 	Persistent bool   `json:"persistent"`
 
 	// Host string resolved to an IP, including DNS lookup.
-	host net.IP
-	DelIfAddr bool
+	host       net.IP
+	delIfAddr  bool
 
 	// Protocol string converted to a protocol number.
-	protocol uint16
+	protocol   uint16
 }
 
 // Validate fills missing fields and validates virtual service configuration.

--- a/core/options.go
+++ b/core/options.go
@@ -57,6 +57,7 @@ type ServiceOptions struct {
 
 	// Host string resolved to an IP, including DNS lookup.
 	host net.IP
+	DelIfAddr bool
 
 	// Protocol string converted to a protocol number.
 	protocol uint16


### PR DESCRIPTION
#35 PR is merged so we can add VIP(s) to IPVS host interfaces.
But If we remove services, gorb doesn't remove these VIP(s) from interfaces and it'll be remained.
So, I add a boolean value to ServiceOptions to determine interface address is add by gorb.
And when removing services, remove interface VIP(s) if it were added by gorb.

Signed-off-by: albam.c <albam.c@navercorp.com>