### PR TITLE
Add lock/unlock codes for kvstore

### DIFF
--- a/core/store.go
+++ b/core/store.go
@@ -102,14 +102,14 @@ func (s *Store) Sync() {
 		return
 	}
 	// build external services map
-	services, err := s.getExternalServices()
+	services, err := s.getServices()
 	if err != nil {
 		log.Errorf("error while get services: %s", err)
 		(*s.locker).Unlock()
 		return
 	}
 	// build external backends map
-	backends, err := s.getExternalBackends()
+	backends, err := s.getBackends()
 	if err != nil {
 		log.Errorf("error while get backends: %s", err)
 		(*s.locker).Unlock()
@@ -120,7 +120,15 @@ func (s *Store) Sync() {
 	s.ctx.Synchronize(services, backends)
 }
 
-func (s *Store) getExternalServices() (map[string]*ServiceOptions, error) {
+func (s *Store) GetServices() (map[string]*ServiceOptions, error) {
+	if _, err := (*s.locker).Lock(nil); err != nil {
+		return nil, err
+	}
+	defer (*s.locker).Unlock()
+	return s.getServices()
+}
+
+func (s *Store) getServices() (map[string]*ServiceOptions, error) {
 	services := make(map[string]*ServiceOptions)
 	// build external service map (temporary all services)
 	kvlist, err := s.kvstore.List(s.storeServicePath)
@@ -141,7 +149,15 @@ func (s *Store) getExternalServices() (map[string]*ServiceOptions, error) {
 	return services, nil
 }
 
-func (s *Store) getExternalBackends() (map[string]*BackendOptions, error) {
+func (s *Store) GetBackends() (map[string]*BackendOptions, error) {
+	if _, err := (*s.locker).Lock(nil); err != nil {
+		return nil, err
+	}
+	defer (*s.locker).Unlock()
+	return s.getBackends()
+}
+
+func (s *Store) getBackends() (map[string]*BackendOptions, error) {
 	backends := make(map[string]*BackendOptions)
 	// build external backend map
 	kvlist, err := s.kvstore.List(s.storeBackendPath)

--- a/core/store.go
+++ b/core/store.go
@@ -71,8 +71,6 @@ func NewStore(storeUrl, storeServicePath, storeBackendPath string, context *Cont
 		locker:           &locker,
 	}
 
-	context.SetStore(store)
-
 	return store, nil
 }
 

--- a/main.go
+++ b/main.go
@@ -98,6 +98,7 @@ func main() {
 		if err != nil {
 			log.Fatalf("error while initializing external store sync: %s", err)
 		}
+		ctx.SetStore(store)
 		store.StartSync(*storeTimeout)
 		defer store.Close()
 	}

--- a/main.go
+++ b/main.go
@@ -94,10 +94,11 @@ func main() {
 
 	// sync with external store
 	if storeURL != nil && len(*storeURL) > 0 {
-		store, err := core.NewStore(*storeURL, *storeServicePath, *storeBackendPath, *storeTimeout, ctx)
+		store, err := core.NewStore(*storeURL, *storeServicePath, *storeBackendPath, ctx)
 		if err != nil {
 			log.Fatalf("error while initializing external store sync: %s", err)
 		}
+		store.StartSync(*storeTimeout)
 		defer store.Close()
 	}
 


### PR DESCRIPTION
### What I did
Add a lock/unlock codes for kvstore

### How I did
- libkv support Lock(), Unlock() functions.
- create a kvstore lock for path (uri.path + "/" + "gorblock")
- use this lock before program exits
 
### How to test it
- no error message from libkv :)
- I'll update a case soon... 

### What to do
- log level missing
  - According to this [stackoverflow thread](http://stackoverflow.com/questions/18361750/correct-approach-to-global-logging-in-golang), If I set logrus parameter, it'll be effected every go file which import logrus files.
  - But I found that if main.go set debug level "debug", context.go or store.go logrus's loglevel is still info.
  - I couldn't find why it happens but I guess It can be a multi-import logrus problems. Any helps will be appreciated... 

### references
https://github.com/docker/libkv/blob/master/docs/examples.md
