### PR TITLE
Support health checks on different ip/port

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ This scheduler has two flags: sh-fallback, which enables fallback to a different
         "type": "none|tcp|http",
         "args": {
             "method": "GET",
+            "port": 54321,
             "path": "/health",
             "expect": 200
         },

--- a/pulse/http.go
+++ b/pulse/http.go
@@ -52,9 +52,12 @@ func newGETDriver(host string, port uint16, opts util.DynamicMap) (Driver, error
 		return errRedirects
 	}}
 
+	pulseHost := opts.Get("host", host).(string)
+	pulsePort := opts.Get("port", int(port)).(int)
+
 	u := url.URL{
 		Scheme: "http",
-		Host:   fmt.Sprintf("%s:%d", host, port),
+		Host:   fmt.Sprintf("%s:%d", pulseHost, pulsePort),
 		Path:   opts.Get("path", "/").(string)}
 
 	r, err := http.NewRequest(opts.Get("method", "GET").(string), u.String(), nil)


### PR DESCRIPTION
Allow defining health checks that don't share ip/port with
the backend, e.g. UDP backends that have an HTTP endpoint
for metrics, that can be used to verify service health.